### PR TITLE
allow group to be set when submitting an indicator

### DIFF
--- a/cifsdk/client/client.py
+++ b/cifsdk/client/client.py
@@ -154,7 +154,7 @@ def main():
 
     if options.get("submit"):
         print("submitting {0}".format(options.get("submit")))
-        i = Indicator(indicator=args.indicator, tags=args.tags, confidence=args.confidence)
+        i = Indicator(indicator=args.indicator, tags=args.tags, confidence=args.confidence, group=args.group)
         rv = cli.indicators_create(i)
 
         print('success id: {}\n'.format(rv))


### PR DESCRIPTION
When submitting a new indicator, there is no way to set the group.
`$ cif --submit --indicator example4.com --confidence 9 --tags malware --group mygroup`

This will provide a way to set the group so that the indicator object is created appropriately.