### PR TITLE
problem: cifsdk.utils.color taints logging.StreamHandler

### DIFF
--- a/cifsdk/client/client.py
+++ b/cifsdk/client/client.py
@@ -108,6 +108,8 @@ def main():
 
     setup_logging(args)
     logger = logging.getLogger(__name__)
+    if args:
+        from cifsdk.utils import color
 
     o = read_config(args)
     options = vars(args)

--- a/cifsdk/utils/__init__.py
+++ b/cifsdk/utils/__init__.py
@@ -3,7 +3,6 @@ import logging
 from cifsdk.constants import LOG_FORMAT, RUNTIME_PATH, LOGLEVEL, VERSION
 from argparse import ArgumentParser
 import signal
-from . import color
 
 import yaml
 import os


### PR DESCRIPTION
cifsdk.utils.color taints logging.StreamHandler universally when cifsdk.client classes loaded. Changing so color only loads when used interactively (cli client).